### PR TITLE
Fix Issue #162

### DIFF
--- a/ShortStack
+++ b/ShortStack
@@ -3326,6 +3326,15 @@ def analyze_fold(mir_locus, dotbracket, bedfields, merged_bam, args, fai, bam_ty
     if s_rel_start is None:
         return None, None, None
 
+    # Issue #162
+    # miRNA and miRNA* cannot overlap!
+    if s_rel_start < q_rel_start:
+        if s_rel_stop >= q_rel_start:
+            return None, None, None
+    elif q_rel_start < s_rel_start:
+        if q_rel_stop >= s_rel_start:
+            return None, None, None
+
     # Compute position of miR* in genomic coordinates given relative coordinates
     s_gen_start, s_gen_stop = get_star_genomic(new_locus, bedfields, s_rel_start, s_rel_stop)
     if s_gen_start is None:


### PR DESCRIPTION
solved rare issue where ShortStack was reporting microRNA loci where the putative miRNA and miRNA* touched each other on the loop.